### PR TITLE
use ErrorType + @noescape

### DIFF
--- a/Try/WBTry.h
+++ b/Try/WBTry.h
@@ -22,6 +22,6 @@
  @param         finallyBlock            An optional block that is called in the \@finally block.
 
  */
-+ (void)tryBlock:(nonnull void (^)(void))tryBlock  catchAndRethrowBlock:(nullable BOOL (^)(_Nonnull id))catchAndRethrowBlock finallyBlock:(nullable void (^)(void))finallyBlock;
++ (void)tryBlock:( __attribute__((noescape)) void (^ _Nonnull )(void)) tryBlock  catchAndRethrowBlock:(nullable BOOL (^)(_Nonnull id))catchAndRethrowBlock finallyBlock:(nullable void (^)(void))finallyBlock;
 
 @end

--- a/Try/WBTry.m
+++ b/Try/WBTry.m
@@ -9,7 +9,7 @@
 
 @implementation WBTry
 
-+ (void)tryBlock:(nonnull void (^)(void))tryBlock  catchAndRethrowBlock:(nullable BOOL (^)(_Nonnull id))catchAndRethrowBlock finallyBlock:(nullable void (^)(void))finallyBlock {
++ (void)tryBlock:( __attribute__((noescape)) void (^ _Nonnull )(void)) tryBlock  catchAndRethrowBlock:(nullable BOOL (^)(_Nonnull id))catchAndRethrowBlock finallyBlock:(nullable void (^)(void))finallyBlock {
     @try {
         tryBlock();
     }

--- a/Try/trap.swift
+++ b/Try/trap.swift
@@ -7,25 +7,25 @@
 
 import Foundation
 
-public let tryErrorDomain = "Try"
-public let tryExceptionErrorCode = 1
-public let tryExceptionErrorKey = "exception"
+enum TryError: ErrorType {
+    case Exception(e: NSException)
+}
 
 /**
  Wraps a closure in a `WBTry.tryBlock` to catch Objective-C exceptions using the Swift error handling model.
  
  - parameter    block:  The block of code to run within a `WBTry.tryBlock`.
- - throws:      Throws an `NSError` if the wrapped code throws an exception.
+ - throws:      Throws a `TryError` if the wrapped code throws an exception.
 */
-public func trap(block: () -> Void) throws {
-    var exception: AnyObject?
+public func trap(@noescape block: () -> Void) throws {
+    var exception: NSException?
 
     WBTry.tryBlock(block, catchAndRethrowBlock: {
-        exception = $0
+        exception = $0 as? NSException
         return false
     }, finallyBlock: nil)
 
     if let e = exception {
-        throw NSError(domain: tryErrorDomain, code: tryExceptionErrorCode, userInfo: [tryExceptionErrorKey: e])
+        throw TryError.Exception(e: e)
     }
 }


### PR DESCRIPTION
A few enhancements to make code more usable and safe. In spite of objective-c noescape attribute is [useless](http://www.openradar.me/19989922), it would be nice on swift for safety warning.
